### PR TITLE
Fix modules and resources parameters setting

### DIFF
--- a/commands/deploy_command.go
+++ b/commands/deploy_command.go
@@ -155,9 +155,16 @@ func deployProcessParametersSetter() ProcessParametersSetter {
 		processBuilder.Parameter("noFailOnMissingPermissions", strconv.FormatBool(GetBoolOpt(noFailOnMissingPermissionsOpt, optionValues)))
 		processBuilder.Parameter("abortOnError", strconv.FormatBool(GetBoolOpt(abortOnErrorOpt, optionValues)))
 		processBuilder.Parameter("skipOwnershipValidation", strconv.FormatBool(GetBoolOpt(skipOwnershipValidationOpt, optionValues)))
-		processBuilder.Parameter("modulesForDeployment", strings.Join(modulesList.getElements(), ","))
-		processBuilder.Parameter("resourcesForDeployment", strings.Join(resourcesList.getElements(), ","))
+		processBuilder.Parameter("modulesForDeployment", getMtaElementsList(modulesList.getElements(), optionValues, allModulesOpt))
+		processBuilder.Parameter("resourcesForDeployment", getMtaElementsList(resourcesList.getElements(), optionValues, allResourcesOpt))
 	}
+}
+
+func getMtaElementsList(mtaElements []string, optionValues map[string]interface{}, allElementsOpt string) string {
+	if GetBoolOpt(allElementsOpt, optionValues) {
+		return ""
+	}
+	return strings.Join(mtaElements, ",")
 }
 
 // GetBoolOpt gets and dereferences the pointer identified by the specified name.


### PR DESCRIPTION
#### Description: 
This commit is checking whether there are some resources or modules specified for deployment and if there are such, then they are added to the process parameters and will be used for deployment. If --all-modules is specified, then nothing will be added to the process parameters and the deployment will assume that all the modules are contained in the archive and will deploy them. The same applies for the resources.


#### Issue: LMCROSSITXSADEPLOY-784

