### PR TITLE
Concatenate elements with the same Name attribute

### DIFF
--- a/util/archive_builder.go
+++ b/util/archive_builder.go
@@ -207,12 +207,25 @@ func copy(src, dest string) error {
 
 func buildSection(elements map[string]string, locatorName string) []ManifestSection {
 	result := make([]ManifestSection, 0)
+	for key, value := range concatenateElementsWithSameValue(elements) {
+		manifestSectionBuilder := NewMtaManifestSectionBuilder()
+		manifestSectionBuilder.Name(key)
+		manifestSectionBuilder.Attribute(locatorName, strings.Join(value, ","))
+		result = append(result, manifestSectionBuilder.Build())
+	}
+	return result
+}
+
+func concatenateElementsWithSameValue(elements map[string]string) map[string][]string {
+	result := make(map[string][]string)
 	for key, value := range elements {
-		if value != "" {
-			manifestSectionBuilder := NewMtaManifestSectionBuilder()
-			manifestSectionBuilder.Name(value)
-			manifestSectionBuilder.Attribute(locatorName, key)
-			result = append(result, manifestSectionBuilder.Build())
+		if value == "" {
+			continue
+		}
+		if len(result[value]) != 0 {
+			result[value] = append(result[value], key)
+		} else {
+			result[value] = []string{key}
 		}
 	}
 	return result

--- a/util/archive_handler.go
+++ b/util/archive_handler.go
@@ -102,6 +102,8 @@ func CreateMtaArchive(source, target string) error {
 		}
 		header.Method = zip.Deflate
 
+		header.Name = filepath.ToSlash(header.Name)
+
 		writer, err := archive.CreateHeader(header)
 		if err != nil {
 			return err


### PR DESCRIPTION
#### Description: 
As the MANIFEST.MF is coming from the JAR spec, the Name attribute is a unique one. This means that when more than one Name attributes, with same value, are used, only one will be used when processing the MANIFEST.MF. This commit merges the manifest entries which contain the same Name attribute
