### PR TITLE
Avoid duplication of error messages

### DIFF
--- a/commands/action_test.go
+++ b/commands/action_test.go
@@ -153,11 +153,10 @@ var _ = Describe("Actions", func() {
 					mtaClient = fakes.NewFakeMtaClientBuilder().
 						GetMtaOperation(operationID, "messages", operation, nil).
 						Build()
-					output, status := oc.CaptureOutputAndStatus(func() int {
+					_, status := oc.CaptureOutputAndStatus(func() int {
 						return action.Execute(operationID, mtaClient).ToInt()
 					})
 					ex.ExpectNonZeroStatus(status)
-					ex.ExpectMessageOnLine(output, "Could not create application 'foo'", 0)
 				})
 			})
 		})

--- a/commands/execution_monitor.go
+++ b/commands/execution_monitor.go
@@ -87,7 +87,7 @@ func (m *ExecutionMonitor) Monitor() ExecutionStatus {
 				ui.Failed("There is not error message for operation with id %s", m.operationID)
 				return Failure
 			}
-			ui.Say("Process failed: %s", messageInError.Text)
+			ui.Say("Process failed.")
 			m.reportAvaiableActions(m.operationID)
 			m.reportCommandForDownloadOfProcessLogs(m.operationID)
 			return Failure

--- a/commands/execution_monitor_test.go
+++ b/commands/execution_monitor_test.go
@@ -45,7 +45,7 @@ var _ = Describe("ExecutionMonitor", func() {
 			}
 
 			if errorMessage != "" {
-				lines = append(lines, fmt.Sprintf("Process failed: %s\n", errorMessage))
+				lines = append(lines, fmt.Sprintf("Process failed.\n"))
 				lines = append(lines, fmt.Sprintf("Use \"cf %s -i %s -a retry\" to retry the process.\n", commandName, processID))
 				lines = append(lines, fmt.Sprintf("Use \"cf %s -i %s -a abort\" to abort the process.\n", commandName, processID))
 				lines = append(lines, fmt.Sprintf("Use \"cf dmol -i %s\" to download the logs of the process.\n", processID))


### PR DESCRIPTION
#### Description: 
When receiving error messages from backend, plugin should not return one more time the last error.

#### Issue: 
Jira: LMCROSSITXSADEPLOY-1536

