### PR TITLE
Create log files with correct file suffix

### DIFF
--- a/commands/download_mta_op_logs_command.go
+++ b/commands/download_mta_op_logs_command.go
@@ -146,6 +146,8 @@ func createDownloadDirectory(downloadDirName string) (string, error) {
 }
 
 func saveLogContent(downloadDir, logID string, content *string) error {
-	ui.Say("  %s", logID)
-	return ioutil.WriteFile(downloadDir+"/"+logID, []byte(*content), 0644)
+	var suffix = ".log"
+	var fileName = logID + suffix
+	ui.Say("  %s", fileName)
+	return ioutil.WriteFile(downloadDir+"/"+fileName, []byte(*content), 0644)
 }


### PR DESCRIPTION
#### Description: 
Log files should have the file suffix `.log`


#### Issue: #80 

