### PR TITLE
Fix backend url discovery when '-u' option is used

### DIFF
--- a/commands/deploy_command.go
+++ b/commands/deploy_command.go
@@ -85,17 +85,17 @@ func (c *DeployCommand) GetPluginCommand() plugin.Command {
    Perform action on an active deploy operation
    cf deploy -i OPERATION_ID -a ACTION [-u URL]`,
 			Options: map[string]string{
-				extDescriptorsOpt:                                  "Extension descriptors",
-				deployServiceURLOpt:                                "Deploy service URL, by default 'deploy-service.<system-domain>'",
-				timeoutOpt:                                         "Start timeout in seconds",
-				versionRuleOpt:                                     "Version rule (HIGHER, SAME_HIGHER, ALL)",
-				operationIDOpt:                                     "Active deploy operation id",
-				actionOpt:                                          "Action to perform on active deploy operation (abort, retry, monitor)",
-				forceOpt:                                           "Force deploy without confirmation for aborting conflicting processes",
-				moduleOpt:                                          "Deploy list of modules which are contained in the deployment descriptor, in the current location",
-				resourceOpt:                                        "Deploy list of resources which are contained in the deployment descriptor, in the current location",
-				util.GetShortOption(noStartOpt):                    "Do not start apps",
-				util.GetShortOption(useNamespacesOpt):              "Use namespaces in app and service names",
+				extDescriptorsOpt:                     "Extension descriptors",
+				deployServiceURLOpt:                   "Deploy service URL, by default 'deploy-service.<system-domain>'",
+				timeoutOpt:                            "Start timeout in seconds",
+				versionRuleOpt:                        "Version rule (HIGHER, SAME_HIGHER, ALL)",
+				operationIDOpt:                        "Active deploy operation id",
+				actionOpt:                             "Action to perform on active deploy operation (abort, retry, monitor)",
+				forceOpt:                              "Force deploy without confirmation for aborting conflicting processes",
+				moduleOpt:                             "Deploy list of modules which are contained in the deployment descriptor, in the current location",
+				resourceOpt:                           "Deploy list of resources which are contained in the deployment descriptor, in the current location",
+				util.GetShortOption(noStartOpt):       "Do not start apps",
+				util.GetShortOption(useNamespacesOpt): "Use namespaces in app and service names",
 				util.GetShortOption(noNamespacesForServicesOpt):    "Do not use namespaces in service names",
 				util.GetShortOption(deleteServicesOpt):             "Recreate changed services / delete discontinued services",
 				util.GetShortOption(deleteServiceKeysOpt):          "Delete existing service keys and apply the new ones",
@@ -193,7 +193,7 @@ func (c *DeployCommand) Execute(args []string) ExecutionStatus {
 	var host string
 
 	// Parse command arguments and check for required options
-	flags, err := c.CreateFlags(&host)
+	flags, err := c.CreateFlags(&host, args)
 	if err != nil {
 		ui.Failed(err.Error())
 		return Failure

--- a/commands/download_mta_op_logs_command.go
+++ b/commands/download_mta_op_logs_command.go
@@ -49,7 +49,7 @@ func (c *DownloadMtaOperationLogsCommand) Execute(args []string) ExecutionStatus
 	var downloadDirName string
 
 	// Parse command arguments and check for required options
-	flags, err := c.CreateFlags(&host)
+	flags, err := c.CreateFlags(&host, args)
 	if err != nil {
 		ui.Failed(err.Error())
 		return Failure

--- a/commands/flags_parser.go
+++ b/commands/flags_parser.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/log"
-	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/ui"
 )
 
 // CommandFlagsDefiner is a function used during the execution of the deploy
@@ -80,11 +79,6 @@ func NewDefaultCommandFlagsParser(positionalArgNames []string) DefaultCommandFla
 
 // ParseFlags see DefaultCommandFlagsParser
 func (p DefaultCommandFlagsParser) ParseFlags(flags *flag.FlagSet, args []string) error {
-	customDeployServiceURL := GetOptionValue(args, deployServiceURLOpt)
-	if customDeployServiceURL != "" {
-		ui.Say(fmt.Sprintf("**Attention: You've specified a custom Deploy Service URL (%s) via the command line option 'u'. The application listening on that URL may be outdated, contain bugs or unreleased features or may even be modified by a potentially untrused person. Use at your own risk.**\n", customDeployServiceURL))
-	}
-
 	// Check for missing positional arguments
 	positionalArgsCount := len(p.positionalArgNames)
 	if len(args) < positionalArgsCount {

--- a/commands/mta_command.go
+++ b/commands/mta_command.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cloudfoundry/cli/cf/formatters"
 	"github.com/cloudfoundry/cli/cf/terminal"
 	"github.com/cloudfoundry/cli/plugin"
-	"github.com/cloudfoundry/cli/plugin/models"
+	plugin_models "github.com/cloudfoundry/cli/plugin/models"
 )
 
 // MtaCommand is a command for listing a deployed MTA
@@ -42,7 +42,7 @@ func (c *MtaCommand) Execute(args []string) ExecutionStatus {
 	var host string
 
 	// Parse command arguments and check for required options
-	flags, err := c.CreateFlags(&host)
+	flags, err := c.CreateFlags(&host, args)
 	if err != nil {
 		ui.Failed(err.Error())
 		return Failure

--- a/commands/mta_operations_command.go
+++ b/commands/mta_operations_command.go
@@ -41,7 +41,7 @@ func (c *MtaOperationsCommand) Execute(args []string) ExecutionStatus {
 	var all bool
 
 	// Parse command arguments and check for required options
-	flags, err := c.CreateFlags(&host)
+	flags, err := c.CreateFlags(&host, args)
 	if err != nil {
 		ui.Failed(err.Error())
 		return Failure

--- a/commands/mtas_command.go
+++ b/commands/mtas_command.go
@@ -35,7 +35,7 @@ func (c *MtasCommand) Execute(args []string) ExecutionStatus {
 	var host string
 
 	// Parse command arguments and check for required options
-	flags, err := c.CreateFlags(&host)
+	flags, err := c.CreateFlags(&host, args)
 	if err != nil {
 		ui.Failed(err.Error())
 		return Failure

--- a/commands/purge_config_command.go
+++ b/commands/purge_config_command.go
@@ -29,7 +29,7 @@ func (c *PurgeConfigCommand) Execute(args []string) ExecutionStatus {
 	log.Tracef("Executing command %q with args %v\n", c.name, args)
 
 	var host string
-	flags, err := c.CreateFlags(&host)
+	flags, err := c.CreateFlags(&host, args)
 	if err != nil {
 		ui.Failed(err.Error())
 		return Failure

--- a/commands/undeploy_command.go
+++ b/commands/undeploy_command.go
@@ -38,11 +38,11 @@ func (c *UndeployCommand) GetPluginCommand() plugin.Command {
    Perform action on an active undeploy operation
    cf undeploy -i OPERATION_ID -a ACTION [-u URL]`,
 			Options: map[string]string{
-				deployServiceURLOpt: "Deploy service URL, by default 'deploy-service.<system-domain>'",
-				operationIDOpt:      "Active undeploy operation id",
-				actionOpt:           "Action to perform on the active undeploy operation (abort, retry, monitor)",
-				forceOpt:            "Force undeploy without confirmation",
-				util.GetShortOption(deleteServicesOpt):             "Delete services",
+				deployServiceURLOpt:                    "Deploy service URL, by default 'deploy-service.<system-domain>'",
+				operationIDOpt:                         "Active undeploy operation id",
+				actionOpt:                              "Action to perform on the active undeploy operation (abort, retry, monitor)",
+				forceOpt:                               "Force undeploy without confirmation",
+				util.GetShortOption(deleteServicesOpt): "Delete services",
 				util.GetShortOption(deleteServiceBrokersOpt):       "Delete service brokers",
 				util.GetShortOption(noRestartSubscribedAppsOpt):    "Do not restart subscribed apps, updated during the undeployment",
 				util.GetShortOption(noFailOnMissingPermissionsOpt): "Do not fail on missing permissions for admin operations",
@@ -65,7 +65,7 @@ func (c *UndeployCommand) Execute(args []string) ExecutionStatus {
 	var deleteServiceBrokers bool
 	var noFailOnMissingPermissions bool
 	var abortOnError bool
-	flags, err := c.CreateFlags(&host)
+	flags, err := c.CreateFlags(&host, args)
 	if err != nil {
 		ui.Failed(err.Error())
 		return Failure


### PR DESCRIPTION
#### Description
This PR was created because '-u' option was not treated in the same way as the env var DEPLOY_SERVICE_URL and plugin checks every shared domain for running backend.
This is a problem when there is not running deploy service on any shared domain.

#### Issue: 
LMCROSSITXSADEPLOY-1694

