### PR TITLE
Streaming archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.10
+
+RUN apk --no-cache add curl  
+# download SAP root certificates
+RUN curl -sSL -f -k http://aia.pki.co.sap.com/aia/SAPNetCA_G2.crt -o /usr/local/share/ca-certificates/SAPNetCA_G2.crt && \
+    curl -sSL -f -k http://aia.pki.co.sap.com/aia/SAP%20Global%20Root%20CA.crt -o /usr/local/share/ca-certificates/SAP%20Global%20Root%20CA.crt && \
+    update-ca-certificates
+
+# Install Cloud Foundry cli
+RUN curl -sSL -f -k 'https://cli.run.pivotal.io/stable?release=linux64-binary&source=github' -o /tmp/cf-cli.tgz
+RUN mkdir -p /usr/local/bin && \
+  tar -xzf /tmp/cf-cli.tgz -C /usr/local/bin && \
+  cf --version && \
+  rm -fv /tmp/cf-cli.tgz
+
+COPY multiapps-plugin.linux64 multiapps-plugin.linux64
+RUN cf install-plugin ./multiapps-plugin.linux64 -f
+ENV I_ACCEPT_THE_RISK_OF=CONFLICT 
+ENV I_WANT_TO_STREAM_THE_MTA_FROM=FILE
+CMD [  
+  echo 'USAGE: mkfifo mtaPipe.mtar; I_ACCEPT_THE_RISK_OF=CONFLICT I_WANT_TO_STREAM_THE_MTA_FROM=FILE cf deploy mtaPipe.mtar & '
+  echo '...... curl https://github.wdf.sap.corp/raw/xs2ds/XSOQTests/master/test_resources/health-check/anatz-staticfile.mtar >> mtaPipe.mtar'
+  ]

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ function build() {
     local plugin_name=$4
 
     echo calling to build for $platform $arch
-    GOOS=$platform GOARCH=$arch go build \
+    CGO_ENABLED=0 GOOS=$platform GOARCH=$arch go build \
         -ldflags "-X main.Version=${version}" \
         -o ${plugin_name}
 }
@@ -34,8 +34,10 @@ function createBuildMetadataFiles() {
 	grep -Pzoa "(?s)## v${version}(.*?)##" CHANGELOG.md | grep -va "##" | tr -s '\n' '\n' > ${folder}/changelog
 }
 
-script_dir="$(dirname -- "$(realpath -- "${BASH_SOURCE[0]}")")"
-cd "${script_dir}"
+if [ ! -f "build.sh" ] | [ ! -f "LICENSE" ]; then
+   echo "Please run with the project root as working directory";
+   exit 1 ; 
+fi
 
 BUILD_FOLDER=build
 PLUGIN_NAME_WIN_32=multiapps-plugin.win32
@@ -54,8 +56,9 @@ build $version windows 386 $PLUGIN_NAME_WIN_32
 build $version windows amd64 $PLUGIN_NAME_WIN_64
 build $version darwin amd64 $PLUGIN_NAME_OSX
 
-mkdir $BUILD_FOLDER -p
+mkdir -p $BUILD_FOLDER
 createBuildMetadataFiles $version $BUILD_FOLDER
 movePluginsToBuildFolder $BUILD_FOLDER
+cp Dockerfile $BUILD_FOLDER/
 cd $BUILD_FOLDER
 copyPluginsWithOldNames

--- a/commands/base_command.go
+++ b/commands/base_command.go
@@ -28,8 +28,6 @@ import (
 )
 
 const (
-	// DeployServiceURLEnv is the deploy service URL environment variable
-	DeployServiceURLEnv           = "DEPLOY_SERVICE_URL"
 	deployServiceURLOpt           = "u"
 	operationIDOpt                = "i"
 	actionOpt                     = "a"

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -12,6 +12,10 @@ const (
 	ChunkSizeInMBEnv = "CHUNK_SIZE_IN_MB"
 	// TargetURLEnv Defines the URL of the deploy service
 	TargetURLEnv = "DEPLOY_SERVICE_URL"
+	// I accept the risk of conflicts env variable
+	IAcceptTheRiskOfEnv = "I_ACCEPT_THE_RISK_OF"
+	// I want to stream the MTA env variable
+	IWantToStreamTheMTAFromEnv = "I_WANT_TO_STREAM_THE_MTA_FROM"
 	// DefaultChunkSizeInMB ...
 	DefaultChunkSizeInMB = uint64(45)
 )
@@ -37,4 +41,15 @@ func GetTargetURL() string {
 		ui.Say("Attention: You've specified a custom Deploy Service URL (%s) via the environment variable \"%s\". The application listening on that URL may be outdated, contain bugs or unreleased features or may even be modified by a potentially untrused person. Use at your own risk.\n", targetURL, TargetURLEnv)
 	}
 	return targetURL
+}
+
+// IsStreamingFlagSet gives answer wheter the user wants to stream the mta or not
+func IsStreamingFlagSet() bool {
+	iAcceptTheRiskOfConflict := os.Getenv(IAcceptTheRiskOfEnv)
+	iWantToStreamTheMTA := os.Getenv(IWantToStreamTheMTAFromEnv)
+	if iAcceptTheRiskOfConflict == "CONFLICT" && iWantToStreamTheMTA == "FILE" {
+		ui.Say("Attention: You've requested streaming the mta to the deploy-service. Conflict checks and partial deploy are disabled")
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
#### Description: 
Allows for the mta archive to be streamed to ds(e.g. through a named pipe while it's being downloaded) instead of already existing on the file system.

Allows for orchestration in a minimalistic docker container with very small memory/hdd footprint.

NOTE: mta operations conflict prevention is not taking care of. Chunking of the archive is also not considered - CHUNK_SIZE env var may have to be configured to a large number in order to work with larger MTA
