### PR TITLE
Modified build.sh to accomodate static builds.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,10 +12,25 @@ function build() {
         -o ${plugin_name}
 }
 
+function buildstatic() {
+    local version=$1
+    local platform=$2
+    local arch=$3
+    local plugin_name=$4
+
+    echo calling to build static for $platform $arch
+    CGO_ENABLED=0 GOOS=$platform GOARCH=$arch go build -a -tags netgo \
+        -ldflags "-w -extldflags \"-static\" -X main.Version=${version}" \
+        -o ${plugin_name}
+}
+
 function copyPluginsWithOldNames() {
     cp $PLUGIN_NAME_WIN_64 $OLD_PLUGIN_NAME_WIN_64
     cp $PLUGIN_NAME_LINUX_64 $OLD_PLUGIN_NAME_LINUX_64
     cp $PLUGIN_NAME_OSX $OLD_PLUGIN_NAME_OSX
+    cp $PLUGIN_NAME_STATIC_WIN_64 $OLD_PLUGIN_NAME_STATIC_WIN_64
+    cp $PLUGIN_NAME_STATIC_LINUX_64 $OLD_PLUGIN_NAME_STATIC_LINUX_64
+    cp $PLUGIN_NAME_STATIC_OSX $OLD_PLUGIN_NAME_STATIC_OSX
 }
 
 function movePluginsToBuildFolder() {
@@ -25,6 +40,11 @@ function movePluginsToBuildFolder() {
     mv $PLUGIN_NAME_LINUX_32 $folder
     mv $PLUGIN_NAME_LINUX_64 $folder
     mv $PLUGIN_NAME_OSX $folder
+    mv $PLUGIN_NAME_STATIC_WIN_32 $folder
+    mv $PLUGIN_NAME_STATIC_WIN_64 $folder
+    mv $PLUGIN_NAME_STATIC_LINUX_32 $folder
+    mv $PLUGIN_NAME_STATIC_LINUX_64 $folder
+    mv $PLUGIN_NAME_STATIC_OSX $folder
 }
 
 function createBuildMetadataFiles() {
@@ -47,12 +67,27 @@ OLD_PLUGIN_NAME_WIN_64=mta_plugin_windows_amd64.exe
 OLD_PLUGIN_NAME_LINUX_64=mta_plugin_linux_amd64
 OLD_PLUGIN_NAME_OSX=mta_plugin_darwin_amd64
 
+PLUGIN_NAME_STATIC_WIN_32=multiapps-plugin-static.win32
+PLUGIN_NAME_STATIC_WIN_64=multiapps-plugin-static.win64
+PLUGIN_NAME_STATIC_LINUX_32=multiapps-plugin-static.linux32
+PLUGIN_NAME_STATIC_LINUX_64=multiapps-plugin-static.linux64
+PLUGIN_NAME_STATIC_OSX=multiapps-plugin-static.osx
+OLD_PLUGIN_NAME_STATIC_WIN_64=mta_plugin_static_windows_amd64.exe
+OLD_PLUGIN_NAME_STATIC_LINUX_64=mta_plugin_static_linux_amd64
+OLD_PLUGIN_NAME_STATIC_OSX=mta_plugin_static_darwin_amd64
+
 version=$(<cfg/VERSION)
 build $version linux 386 $PLUGIN_NAME_LINUX_32
 build $version linux amd64 $PLUGIN_NAME_LINUX_64
 build $version windows 386 $PLUGIN_NAME_WIN_32
 build $version windows amd64 $PLUGIN_NAME_WIN_64
 build $version darwin amd64 $PLUGIN_NAME_OSX
+
+buildstatic $version linux 386 $PLUGIN_NAME_STATIC_LINUX_32
+buildstatic $version linux amd64 $PLUGIN_NAME_STATIC_LINUX_64
+buildstatic $version windows 386 $PLUGIN_NAME_STATIC_WIN_32
+buildstatic $version windows amd64 $PLUGIN_NAME_STATIC_WIN_64
+buildstatic $version darwin amd64 $PLUGIN_NAME_STATIC_OSX
 
 mkdir $BUILD_FOLDER -p
 createBuildMetadataFiles $version $BUILD_FOLDER

--- a/build.sh
+++ b/build.sh
@@ -94,3 +94,4 @@ createBuildMetadataFiles $version $BUILD_FOLDER
 movePluginsToBuildFolder $BUILD_FOLDER
 cd $BUILD_FOLDER
 copyPluginsWithOldNames
+


### PR DESCRIPTION

#### Description: 
<!-- Why you are making this pull request
What the pull request changes
Any new design choices made
Areas to focus on for recommendations or to verify correct implementation
Any research you might have done -->
When building cf containers with cf-cli and adding Multiapps plugin, the installation of the same fails because the plugin is not static build but is dependent on libraries, which are not being provided by the container.

> 
> phani@linux-gyok:~/go/src/github.com/cloudfoundry-incubator/multiapps-cli-plugin> ldd build/mta_plugin_linux_amd64 
> 	linux-vdso.so.1 (0x00007fff57996000)
> 	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f3736f2d000)
> 	libc.so.6 => /lib64/libc.so.6 (0x00007f3736b8c000)
> 	/lib64/ld-linux-x86-64.so.2 (0x00007f373714a000)
> 


