### PR TITLE
Objectify configuration

### DIFF
--- a/commands/base_command_test.go
+++ b/commands/base_command_test.go
@@ -14,6 +14,7 @@ import (
 	mtafake "github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/mtaclient/fakes"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/restclient/fakes"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/commands"
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/configuration"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/testutil"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/ui"
 	util_fakes "github.com/cloudfoundry-incubator/multiapps-cli-plugin/util/fakes"
@@ -126,7 +127,7 @@ var _ = Describe("BaseCommand", func() {
 				Build()
 			deployServiceURLCalculator := util_fakes.NewDeployServiceURLFakeCalculator("deploy-service.test.ondemand.com")
 
-			command.InitializeAll("test", fakeCliConnection, testutil.NewCustomTransport(http.StatusOK, nil), nil, testClientFactory, testTokenFactory, deployServiceURLCalculator)
+			command.InitializeAll("test", fakeCliConnection, testutil.NewCustomTransport(http.StatusOK, nil), nil, testClientFactory, testTokenFactory, deployServiceURLCalculator, configuration.NewSnapshot())
 		})
 		Context("with valid ongoing operations", func() {
 			It("should abort and exit with zero status", func() {
@@ -184,7 +185,7 @@ var _ = Describe("BaseCommand", func() {
 				ExecuteAction("test-process-id", "abort", mtaclient.ResponseHeader{}, nil).
 				ExecuteAction("test-process-id", "retry", mtaclient.ResponseHeader{Location: "operations/test-process-id?embed=messages"}, nil).Build()
 			deployServiceURLCalculator := util_fakes.NewDeployServiceURLFakeCalculator("deploy-service.test.ondemand.com")
-			command.InitializeAll("test", fakeCliConnection, testutil.NewCustomTransport(200, nil), nil, testClientfactory, testTokenFactory, deployServiceURLCalculator)
+			command.InitializeAll("test", fakeCliConnection, testutil.NewCustomTransport(200, nil), nil, testClientfactory, testTokenFactory, deployServiceURLCalculator, configuration.NewSnapshot())
 		})
 		Context("with valid process id and valid action id", func() {
 			It("should abort and exit with zero status", func() {

--- a/commands/deploy_command_test.go
+++ b/commands/deploy_command_test.go
@@ -12,6 +12,7 @@ import (
 	mtafake "github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/mtaclient/fakes"
 
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/commands"
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/configuration"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/testutil"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/ui"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/util"
@@ -130,7 +131,7 @@ var _ = Describe("DeployCommand", func() {
 			command = commands.NewDeployCommand()
 			testTokenFactory := commands.NewTestTokenFactory(cliConnection)
 			deployServiceURLCalculator := util_fakes.NewDeployServiceURLFakeCalculator("deploy-service.test.ondemand.com")
-			command.InitializeAll(name, cliConnection, testutil.NewCustomTransport(200, nil), nil, testClientFactory, testTokenFactory, deployServiceURLCalculator)
+			command.InitializeAll(name, cliConnection, testutil.NewCustomTransport(200, nil), nil, testClientFactory, testTokenFactory, deployServiceURLCalculator, configuration.NewSnapshot())
 		})
 
 		// unknown flag - error

--- a/commands/download_mta_op_logs_command_test.go
+++ b/commands/download_mta_op_logs_command_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/models"
 	mtafake "github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/mtaclient/fakes"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/commands"
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/configuration"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/testutil"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/ui"
 	util_fakes "github.com/cloudfoundry-incubator/multiapps-cli-plugin/util/fakes"
@@ -67,7 +68,7 @@ var _ = Describe("DownloadMtaOperationLogsCommand", func() {
 			command = &commands.DownloadMtaOperationLogsCommand{}
 			testTokenFactory := commands.NewTestTokenFactory(cliConnection)
 			deployServiceURLCalculator := util_fakes.NewDeployServiceURLFakeCalculator("deploy-service.test.ondemand.com")
-			command.InitializeAll(name, cliConnection, testutil.NewCustomTransport(200, nil), nil, clientFactory, testTokenFactory, deployServiceURLCalculator)
+			command.InitializeAll(name, cliConnection, testutil.NewCustomTransport(200, nil), nil, clientFactory, testTokenFactory, deployServiceURLCalculator, configuration.NewSnapshot())
 		})
 
 		// unknown flag - error

--- a/commands/file_uploader_test.go
+++ b/commands/file_uploader_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/models"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/mtaclient/fakes"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/commands"
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/configuration"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/testutil"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/ui"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/util"
@@ -43,7 +44,7 @@ var _ = Describe("FileUploader", func() {
 				client := fakeSlmpClientBuilder.GetMtaFiles([]*models.FileMetadata{}, nil).Build()
 
 				output := oc.CaptureOutput(func() {
-					fileUploader = commands.NewFileUploader([]string{}, client)
+					fileUploader = commands.NewFileUploader([]string{}, client, configuration.DefaultChunkSizeInMB)
 					uploadedFiles, status = fileUploader.UploadFiles()
 				})
 				ex.ExpectSuccess(status.ToInt(), output)
@@ -56,7 +57,7 @@ var _ = Describe("FileUploader", func() {
 				client := fakeSlmpClientBuilder.GetMtaFiles([]*models.FileMetadata{&testutil.SimpleFile}, nil).Build()
 				var uploadedFiles []*models.FileMetadata
 				output := oc.CaptureOutput(func() {
-					fileUploader = commands.NewFileUploader([]string{}, client)
+					fileUploader = commands.NewFileUploader([]string{}, client, configuration.DefaultChunkSizeInMB)
 					uploadedFiles, status = fileUploader.UploadFiles()
 				})
 				ex.ExpectSuccess(status.ToInt(), output)
@@ -72,7 +73,7 @@ var _ = Describe("FileUploader", func() {
 					UploadMtaFile(*testFile, testutil.GetFile(*testFile, testFileDigest), nil).Build()
 				var uploadedFiles []*models.FileMetadata
 				output := oc.CaptureOutput(func() {
-					fileUploader = commands.NewFileUploader([]string{testFileAbsolutePath}, client)
+					fileUploader = commands.NewFileUploader([]string{testFileAbsolutePath}, client, configuration.DefaultChunkSizeInMB)
 					uploadedFiles, status = fileUploader.UploadFiles()
 				})
 				Expect(len(uploadedFiles)).To(Equal(1))
@@ -94,7 +95,7 @@ var _ = Describe("FileUploader", func() {
 					UploadMtaFile(*testFile, testutil.GetFile(*testFile, testFileDigest), nil).Build()
 				var uploadedFiles []*models.FileMetadata
 				output := oc.CaptureOutput(func() {
-					fileUploader = commands.NewFileUploader([]string{testFileAbsolutePath}, client)
+					fileUploader = commands.NewFileUploader([]string{testFileAbsolutePath}, client, configuration.DefaultChunkSizeInMB)
 					uploadedFiles, status = fileUploader.UploadFiles()
 				})
 				ex.ExpectSuccessWithOutput(status.ToInt(), output, []string{
@@ -112,7 +113,7 @@ var _ = Describe("FileUploader", func() {
 					UploadMtaFile(*testFile, fileMetadata, nil).Build()
 				var uploadedFiles []*models.FileMetadata
 				output := oc.CaptureOutput(func() {
-					fileUploader = commands.NewFileUploader([]string{testFileAbsolutePath}, client)
+					fileUploader = commands.NewFileUploader([]string{testFileAbsolutePath}, client, configuration.DefaultChunkSizeInMB)
 					uploadedFiles, status = fileUploader.UploadFiles()
 				})
 				Expect(len(uploadedFiles)).To(Equal(1))
@@ -134,7 +135,7 @@ var _ = Describe("FileUploader", func() {
 					UploadMtaFile(*testFile, &models.FileMetadata{}, errors.New("Unexpected error from the backend")).Build()
 				// var uploadedFiles []*models.FileMetadata
 				output := oc.CaptureOutput(func() {
-					fileUploader = commands.NewFileUploader([]string{testFileAbsolutePath}, client)
+					fileUploader = commands.NewFileUploader([]string{testFileAbsolutePath}, client, configuration.DefaultChunkSizeInMB)
 					_, status = fileUploader.UploadFiles()
 				})
 				// Expect(len(uploadedFiles)).To(Equal(1))

--- a/commands/mta_command_test.go
+++ b/commands/mta_command_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/models"
 	mtafake "github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/mtaclient/fakes"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/commands"
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/configuration"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/testutil"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/ui"
 	util_fakes "github.com/cloudfoundry-incubator/multiapps-cli-plugin/util/fakes"
@@ -64,7 +65,7 @@ var _ = Describe("MtaCommand", func() {
 			testTokenFactory := commands.NewTestTokenFactory(cliConnection)
 			deployServiceURLCalculator := util_fakes.NewDeployServiceURLFakeCalculator("deploy-service.test.ondemand.com")
 
-			command.InitializeAll(name, cliConnection, testutil.NewCustomTransport(200, nil), nil, clientFactory, testTokenFactory, deployServiceURLCalculator)
+			command.InitializeAll(name, cliConnection, testutil.NewCustomTransport(200, nil), nil, clientFactory, testTokenFactory, deployServiceURLCalculator, configuration.NewSnapshot())
 		})
 
 		// wrong arguments - error

--- a/commands/mta_operations_command_test.go
+++ b/commands/mta_operations_command_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/models"
 	mtafake "github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/mtaclient/fakes"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/commands"
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/configuration"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/testutil"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/ui"
 	util_fakes "github.com/cloudfoundry-incubator/multiapps-cli-plugin/util/fakes"
@@ -53,7 +54,7 @@ var _ = Describe("MtaOperationsCommand", func() {
 			command = &commands.MtaOperationsCommand{}
 			testTokenFactory := commands.NewTestTokenFactory(cliConnection)
 			deployServiceURLCalculator := util_fakes.NewDeployServiceURLFakeCalculator("deploy-service.test.ondemand.com")
-			command.InitializeAll(name, cliConnection, testutil.NewCustomTransport(200, nil), nil, clientFactory, testTokenFactory, deployServiceURLCalculator)
+			command.InitializeAll(name, cliConnection, testutil.NewCustomTransport(200, nil), nil, clientFactory, testTokenFactory, deployServiceURLCalculator, configuration.NewSnapshot())
 		})
 
 		Context("with an unknown flag", func() {

--- a/commands/mtas_command_test.go
+++ b/commands/mtas_command_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/models"
 	mtafake "github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/mtaclient/fakes"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/commands"
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/configuration"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/testutil"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/ui"
 	util_fakes "github.com/cloudfoundry-incubator/multiapps-cli-plugin/util/fakes"
@@ -57,7 +58,7 @@ var _ = Describe("MtasCommand", func() {
 			command = &commands.MtasCommand{}
 			testTokenFactory = commands.NewTestTokenFactory(cliConnection)
 			deployServiceURLCalculator := util_fakes.NewDeployServiceURLFakeCalculator("deploy-service.test.ondemand.com")
-			command.InitializeAll(name, cliConnection, testutil.NewCustomTransport(200, nil), nil, clientFactory, testTokenFactory, deployServiceURLCalculator)
+			command.InitializeAll(name, cliConnection, testutil.NewCustomTransport(200, nil), nil, clientFactory, testTokenFactory, deployServiceURLCalculator, configuration.NewSnapshot())
 		})
 
 		// unknown flag - error

--- a/commands/purge_config_command_test.go
+++ b/commands/purge_config_command_test.go
@@ -3,6 +3,7 @@ package commands_test
 import (
 	cli_fakes "github.com/cloudfoundry-incubator/multiapps-cli-plugin/cli/fakes"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/commands"
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/configuration"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/testutil"
 	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/ui"
 	util_fakes "github.com/cloudfoundry-incubator/multiapps-cli-plugin/util/fakes"
@@ -43,7 +44,7 @@ var _ = Describe("PurgeConfigCommand", func() {
 			deployServiceURLCalculator := util_fakes.NewDeployServiceURLFakeCalculator("deploy-service.test.ondemand.com")
 
 			command = &commands.PurgeConfigCommand{}
-			command.InitializeAll(name, cliConnection, testutil.NewCustomTransport(200, nil), nil, clientFactory, testTokenFactory, deployServiceURLCalculator)
+			command.InitializeAll(name, cliConnection, testutil.NewCustomTransport(200, nil), nil, clientFactory, testTokenFactory, deployServiceURLCalculator, configuration.NewSnapshot())
 
 			oc = testutil.NewUIOutputCapturer()
 			ex = testutil.NewUIExpector()

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -10,17 +10,6 @@ const (
 	DefaultChunkSizeInMB = uint64(45)
 )
 
-var ChunkSizeInMBConfigurableProperty = configurableProperty{
-	Name: "MULTIAPPS_UPLOAD_CHUNK_SIZE",
-	DeprecatedNames: []string{
-		"CHUNK_SIZE_IN_MB",
-	},
-	Parser:                chunkSizeInMBParser{},
-	ParsingSuccessMessage: "Attention: You've specified a custom chunk size (%d MB) via the environment variable \"%s\".\n",
-	ParsingFailureMessage: "Attention: You've specified an INVALID custom chunk size (%s) via the environment variable \"%s\". Using default: %d\n",
-	DefaultValue:          DefaultChunkSizeInMB,
-}
-
 var BackendURLConfigurableProperty = configurableProperty{
 	Name: "MULTIAPPS_CONTROLLER_URL",
 	DeprecatedNames: []string{
@@ -32,13 +21,42 @@ var BackendURLConfigurableProperty = configurableProperty{
 	DefaultValue:          "",
 }
 
-// GetBackendURL Retrieves the URL of the backend if set in the environment
-func GetBackendURL() string {
+var ChunkSizeInMBConfigurableProperty = configurableProperty{
+	Name: "MULTIAPPS_UPLOAD_CHUNK_SIZE",
+	DeprecatedNames: []string{
+		"CHUNK_SIZE_IN_MB",
+	},
+	Parser:                chunkSizeInMBParser{},
+	ParsingSuccessMessage: "Attention: You've specified a custom chunk size (%d MB) via the environment variable \"%s\".\n",
+	ParsingFailureMessage: "Attention: You've specified an INVALID custom chunk size (%s) via the environment variable \"%s\". Using default: %d\n",
+	DefaultValue:          DefaultChunkSizeInMB,
+}
+
+type Snapshot struct {
+	backendURL    string
+	chunkSizeInMB uint64
+}
+
+func NewSnapshot() Snapshot {
+	return Snapshot{
+		backendURL:    getBackendURLFromEnvironment(),
+		chunkSizeInMB: getChunkSizeInMBFromEnvironment(),
+	}
+}
+
+func (c Snapshot) GetBackendURL() string {
+	return c.backendURL
+}
+
+func (c Snapshot) GetChunkSizeInMB() uint64 {
+	return c.chunkSizeInMB
+}
+
+func getBackendURLFromEnvironment() string {
 	return getStringProperty(BackendURLConfigurableProperty)
 }
 
-// GetChunkSizeInMB Retrieves the MTAR chunk size from environment or uses the default one
-func GetChunkSizeInMB() uint64 {
+func getChunkSizeInMBFromEnvironment() uint64 {
 	return getUint64Property(ChunkSizeInMBConfigurableProperty)
 }
 

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -28,7 +28,8 @@ var _ = Describe("Configuration", func() {
 			It("should return its value", func() {
 				backendURL := "http://my-multiapps-controller.domain.com"
 				os.Setenv(configuration.BackendURLConfigurableProperty.Name, backendURL)
-				Expect(configuration.GetBackendURL()).To(Equal(backendURL))
+				configurationSnapshot := configuration.NewSnapshot()
+				Expect(configurationSnapshot.GetBackendURL()).To(Equal(backendURL))
 			})
 		})
 		Context("with a set environment variable (deprecated)", func() {
@@ -36,13 +37,15 @@ var _ = Describe("Configuration", func() {
 				if len(configuration.BackendURLConfigurableProperty.DeprecatedNames) > 0 {
 					backendURL := "http://my-multiapps-controller.domain.com"
 					os.Setenv(configuration.BackendURLConfigurableProperty.DeprecatedNames[0], backendURL)
-					Expect(configuration.GetBackendURL()).To(Equal(backendURL))
+					configurationSnapshot := configuration.NewSnapshot()
+					Expect(configurationSnapshot.GetBackendURL()).To(Equal(backendURL))
 				}
 			})
 		})
 		Context("without a set environment variable", func() {
 			It("should return an empty string", func() {
-				Expect(configuration.GetBackendURL()).To(BeEmpty())
+				configurationSnapshot := configuration.NewSnapshot()
+				Expect(configurationSnapshot.GetBackendURL()).To(BeEmpty())
 			})
 		})
 
@@ -62,21 +65,24 @@ var _ = Describe("Configuration", func() {
 				It("should return its value", func() {
 					chunkSizeInMB := uint64(5)
 					os.Setenv(configuration.ChunkSizeInMBConfigurableProperty.Name, strconv.Itoa(int(chunkSizeInMB)))
-					Expect(configuration.GetChunkSizeInMB()).To(Equal(chunkSizeInMB))
+					configurationSnapshot := configuration.NewSnapshot()
+					Expect(configurationSnapshot.GetChunkSizeInMB()).To(Equal(chunkSizeInMB))
 				})
 			})
 			Context("containing zero", func() {
 				It("should return the default value", func() {
 					chunkSizeInMB := 0
 					os.Setenv(configuration.ChunkSizeInMBConfigurableProperty.Name, strconv.Itoa(chunkSizeInMB))
-					Expect(configuration.GetChunkSizeInMB()).To(Equal(configuration.DefaultChunkSizeInMB))
+					configurationSnapshot := configuration.NewSnapshot()
+					Expect(configurationSnapshot.GetChunkSizeInMB()).To(Equal(configuration.DefaultChunkSizeInMB))
 				})
 			})
 			Context("containing a string", func() {
 				It("should return the default value", func() {
 					chunkSizeInMB := "abc"
 					os.Setenv(configuration.ChunkSizeInMBConfigurableProperty.Name, chunkSizeInMB)
-					Expect(configuration.GetChunkSizeInMB()).To(Equal(configuration.DefaultChunkSizeInMB))
+					configurationSnapshot := configuration.NewSnapshot()
+					Expect(configurationSnapshot.GetChunkSizeInMB()).To(Equal(configuration.DefaultChunkSizeInMB))
 				})
 			})
 		})
@@ -85,13 +91,15 @@ var _ = Describe("Configuration", func() {
 				if len(configuration.ChunkSizeInMBConfigurableProperty.DeprecatedNames) > 0 {
 					chunkSizeInMB := uint64(5)
 					os.Setenv(configuration.ChunkSizeInMBConfigurableProperty.DeprecatedNames[0], strconv.Itoa(int(chunkSizeInMB)))
-					Expect(configuration.GetChunkSizeInMB()).To(Equal(chunkSizeInMB))
+					configurationSnapshot := configuration.NewSnapshot()
+					Expect(configurationSnapshot.GetChunkSizeInMB()).To(Equal(chunkSizeInMB))
 				}
 			})
 		})
 		Context("without a set environment variable", func() {
 			It("should return the default value", func() {
-				Expect(configuration.GetChunkSizeInMB()).To(Equal(configuration.DefaultChunkSizeInMB))
+				configurationSnapshot := configuration.NewSnapshot()
+				Expect(configurationSnapshot.GetChunkSizeInMB()).To(Equal(configuration.DefaultChunkSizeInMB))
 			})
 		})
 


### PR DESCRIPTION
We can now create configuration snapshots, instead of retrieving the
different configuration properties individually.

Pros:
- Warnings about custom configurations are printed at the beginning of each command, instead of whenever commands ask for them.
- Warnings about custom configurations are printed only once even when commands ask for them repeatedly.

