### PR TITLE
Add handling for non-normalized paths in mtad.yaml

### DIFF
--- a/bin/install-plugin.sh
+++ b/bin/install-plugin.sh
@@ -4,6 +4,7 @@ set -e
 
 echo -e "Installing plugin..."
 
+cd $GOPATH/src/github.com/cloudfoundry-incubator/multiapps-cli-plugin
 go install
-cf uninstall-plugin MtaPlugin
-cf install-plugin $GOPATH/bin/cf-cli-plugin -f
+cf uninstall-plugin multiapps
+cf install-plugin $GOPATH/bin/multiapps-cli-plugin -f


### PR DESCRIPTION
Write based paths in MANIFEST.MF as well as copy artifacts in base path
in the mta-assembly temp folder.
JIRA: LMCROSSITXSADEPLOY-1967 and LMCROSSITXSADEPLOY-1623

