### PR TITLE
Revert the log ext and rename mta-id flag to mta

### DIFF
--- a/commands/download_mta_op_logs_command.go
+++ b/commands/download_mta_op_logs_command.go
@@ -36,13 +36,13 @@ func (c *DownloadMtaOperationLogsCommand) GetPluginCommand() plugin.Command {
 		UsageDetails: plugin.Usage{
 			Usage: `cf download-mta-op-logs -i OPERATION_ID [-d DIRECTORY] [-u URL]
 
-   cf download-mta-op-logs --mta-id MTA_ID [--last NUM] [-d DIRECTORY] [-u URL]`,
+   cf download-mta-op-logs --mta MTA [--last NUM] [-d DIRECTORY] [-u URL]`,
 			Options: map[string]string{
-				"i":                           "Operation id",
-				util.GetShortOption("mta-id"): "ID of the deployed package",
-				util.GetShortOption("last"):   "Downloads last NUM operation logs. If not specified, logs for each process with the specified MTA_ID are downloaded",
-				"d":                           "Root directory to download logs, by default the current working directory",
-				"u":                           "Deploy service URL, by default 'deploy-service.<system-domain>'",
+				"i":                         "Operation id",
+				util.GetShortOption("mta"):  "ID of the deployed package",
+				util.GetShortOption("last"): "Downloads last NUM operation logs. If not specified, logs for each process with the specified MTA_ID are downloaded",
+				"d":                         "Root directory to download logs, by default the current working directory",
+				"u":                         "Deploy service URL, by default 'deploy-service.<system-domain>'",
 			},
 		},
 	}
@@ -66,7 +66,7 @@ func (c *DownloadMtaOperationLogsCommand) Execute(args []string) ExecutionStatus
 	}
 	flags.StringVar(&operationId, "i", "", "")
 	flags.StringVar(&downloadDirName, "d", "", "")
-	flags.StringVar(&mtaId, "mta-id", "", "")
+	flags.StringVar(&mtaId, "mta", "", "")
 	flags.UintVar(&last, "last", 0, "")
 	parser := NewCommandFlagsParser(flags, NewDefaultCommandFlagsParser([]string{}), dmolCommandFlagsValidator{})
 	err = parser.Parse(args)
@@ -184,12 +184,12 @@ func saveLogContent(downloadDir, logID string, content *string) error {
 type dmolCommandFlagsValidator struct{}
 
 func (dmolCommandFlagsValidator) ValidateParsedFlags(flags *flag.FlagSet) error {
-	if hasValue(flags, "i") && hasValue(flags, "mta-id") {
-		return fmt.Errorf("Option -i and option --mta-id are incompatible")
+	if hasValue(flags, "i") && hasValue(flags, "mta") {
+		return fmt.Errorf("Option -i and option --mta are incompatible")
 	}
 	return NewDefaultCommandFlagsValidator(map[string]bool{
-		"i":      !hasValue(flags, "mta-id"),
-		"mta-id": hasValue(flags, "mta-id")}).ValidateParsedFlags(flags)
+		"i":   !hasValue(flags, "mta"),
+		"mta": hasValue(flags, "mta")}).ValidateParsedFlags(flags)
 }
 
 func hasValue(flags *flag.FlagSet, flagName string) bool {

--- a/commands/download_mta_op_logs_command.go
+++ b/commands/download_mta_op_logs_command.go
@@ -19,7 +19,6 @@ import (
 
 const (
 	defaultDownloadDirPrefix string = "mta-op-"
-	logFilesExtension        string = ".log"
 )
 
 // DownloadMtaOperationLogsCommand is a command for retrieving the logs of an MTA operation
@@ -176,9 +175,8 @@ func createDownloadDirectory(downloadDirName string) (string, error) {
 }
 
 func saveLogContent(downloadDir, logID string, content *string) error {
-	filename := logID + logFilesExtension
-	ui.Say("  %s", filename)
-	return ioutil.WriteFile(filepath.Join(downloadDir, filename), []byte(*content), 0644)
+	ui.Say("  %s", logID)
+	return ioutil.WriteFile(filepath.Join(downloadDir, logID), []byte(*content), 0644)
 }
 
 type dmolCommandFlagsValidator struct{}

--- a/commands/download_mta_op_logs_command_test.go
+++ b/commands/download_mta_op_logs_command_test.go
@@ -140,7 +140,7 @@ var _ = Describe("DownloadMtaOperationLogsCommand", func() {
 				var clientError = baseclient.NewClientError(testutil.ClientError)
 				clientFactory.MtaClient = mtafake.NewFakeMtaClientBuilder().GetMtaOperations(&mtaId, nil, []string{}, []*models.Operation{}, clientError).Build()
 				output, status := oc.CaptureOutputAndStatus(func() int {
-					return command.Execute([]string{"--mta-id", mtaId}).ToInt()
+					return command.Execute([]string{"--mta", mtaId}).ToInt()
 				})
 				ex.ExpectFailureOnLine(status, output, "Process with id 404 not found (status 404): Process with id 404 not found", 0)
 				Expect(exists("mta-op-test")).To(Equal(false))
@@ -195,7 +195,7 @@ var _ = Describe("DownloadMtaOperationLogsCommand", func() {
 			const dir = "mta-op-" + testutil.ProcessID
 			It("should download the last logs for the specified mta and exit with zero status", func() {
 				output, status := oc.CaptureOutputAndStatus(func() int {
-					return command.Execute([]string{"--mta-id", mtaId, "--last", "1"}).ToInt()
+					return command.Execute([]string{"--mta", mtaId, "--last", "1"}).ToInt()
 				})
 				ex.ExpectSuccessWithOutput(status, output, getOutputLines(dir, testutil.ProcessID))
 				expectDirWithLog(dir)
@@ -265,7 +265,7 @@ var _ = Describe("DownloadMtaOperationLogsCommand", func() {
 					GetMtaOperationLogContent("1002", testutil.LogID, testutil.LogContent, nil).
 					GetMtaOperations(&[]string{mtaId}[0], &[]int64{2}[0], nil, operations[1:], nil).Build()
 				output, status := oc.CaptureOutputAndStatus(func() int {
-					return command.Execute([]string{"--mta-id", mtaId, "--last", "2"}).ToInt()
+					return command.Execute([]string{"--mta", mtaId, "--last", "2"}).ToInt()
 				})
 				expectedOutput := append(getOutputLines("mta-op-1001", "1001"), getOutputLines("mta-op-1002", "1002")...)
 				ex.ExpectSuccessWithOutput(status, output, expectedOutput)
@@ -286,7 +286,7 @@ var _ = Describe("DownloadMtaOperationLogsCommand", func() {
 					GetMtaOperationLogContent("1002", testutil.LogID, testutil.LogContent, nil).
 					GetMtaOperations(&[]string{mtaId}[0], &[]int64{2}[0], nil, operations[1:], nil).Build()
 				output, status := oc.CaptureOutputAndStatus(func() int {
-					return command.Execute([]string{"--mta-id", mtaId, "--last", "2", "-d", "custom-dir"}).ToInt()
+					return command.Execute([]string{"--mta", mtaId, "--last", "2", "-d", "custom-dir"}).ToInt()
 				})
 				expectedOutput := append(getOutputLines("custom-dir/mta-op-1001", "1001"), getOutputLines("custom-dir/mta-op-1002", "1002")...)
 				ex.ExpectSuccessWithOutput(status, output, expectedOutput)
@@ -303,9 +303,9 @@ var _ = Describe("DownloadMtaOperationLogsCommand", func() {
 		Context("with mta id and process id", func() {
 			It("should print incorrect usage - incompatible flags and exit with non-zero status", func() {
 				output, status := oc.CaptureOutputAndStatus(func() int {
-					return command.Execute([]string{"--mta-id", mtaId, "-i", testutil.ProcessID}).ToInt()
+					return command.Execute([]string{"--mta", mtaId, "-i", testutil.ProcessID}).ToInt()
 				})
-				ex.ExpectFailure(status, output, "Incorrect usage. Option -i and option --mta-id are incompatible")
+				ex.ExpectFailure(status, output, "Incorrect usage. Option -i and option --mta are incompatible")
 				Expect(cliConnection.CliCommandArgsForCall(0)).To(Equal([]string{"help", name}))
 			})
 		})

--- a/commands/download_mta_op_logs_command_test.go
+++ b/commands/download_mta_op_logs_command_test.go
@@ -49,16 +49,15 @@ var _ = Describe("DownloadMtaOperationLogsCommand", func() {
 					processId, org, space, user),
 				"OK\n",
 				fmt.Sprintf("Saving logs to %s"+string(os.PathSeparator)+"%s...\n", wd, dir),
-				fmt.Sprintf("  %s\n", addLogFileExtension(testutil.LogID)),
+				fmt.Sprintf("  %s\n", testutil.LogID),
 				"OK\n",
 			}
 		}
 
 		var expectDirWithLog = func(dir string) {
 			Expect(exists(dir)).To(Equal(true))
-			logFilename := addLogFileExtension(testutil.LogID)
-			Expect(exists(dir + "/" + logFilename)).To(Equal(true))
-			Expect(contentOf(dir + "/" + logFilename)).To(Equal(testutil.LogContent))
+			Expect(exists(dir + "/" + testutil.LogID)).To(Equal(true))
+			Expect(contentOf(dir + "/" + testutil.LogID)).To(Equal(testutil.LogContent))
 		}
 
 		BeforeEach(func() {
@@ -333,8 +332,4 @@ func exists(dirName string) bool {
 		return true
 	}
 	return false
-}
-
-func addLogFileExtension(filename string) string {
-	return filename + ".log"
 }

--- a/commands/mta_operations_command.go
+++ b/commands/mta_operations_command.go
@@ -22,12 +22,12 @@ func (c *MtaOperationsCommand) GetPluginCommand() plugin.Command {
 		Name:     "mta-ops",
 		HelpText: "List multi-target app operations",
 		UsageDetails: plugin.Usage{
-			Usage: "cf mta-ops [--mta-id MTA_ID] [-u URL] [--last NUM] [--all]",
+			Usage: "cf mta-ops [--mta MTA] [-u URL] [--last NUM] [--all]",
 			Options: map[string]string{
-				"u":                           "Deploy service URL, by default 'deploy-service.<system-domain>'",
-				util.GetShortOption("mta-id"): "ID of the deployed package",
-				util.GetShortOption("last"):   "List last NUM operations",
-				util.GetShortOption("all"):    "List all operations, not just the active ones",
+				"u":                         "Deploy service URL, by default 'deploy-service.<system-domain>'",
+				util.GetShortOption("mta"):  "ID of the deployed package",
+				util.GetShortOption("last"): "List last NUM operations",
+				util.GetShortOption("all"):  "List all operations, not just the active ones",
 			},
 		},
 	}
@@ -48,7 +48,7 @@ func (c *MtaOperationsCommand) Execute(args []string) ExecutionStatus {
 		ui.Failed(err.Error())
 		return Failure
 	}
-	flags.StringVar(&mtaId, "mta-id", "", "")
+	flags.StringVar(&mtaId, "mta", "", "")
 	flags.UintVar(&last, "last", 0, "")
 	flags.BoolVar(&all, "all", false, "")
 	parser := NewCommandFlagsParser(flags, NewDefaultCommandFlagsParser(nil), NewDefaultCommandFlagsValidator(nil))

--- a/commands/mta_operations_command_test.go
+++ b/commands/mta_operations_command_test.go
@@ -331,7 +331,7 @@ var _ = Describe("MtaOperationsCommand", func() {
 						testutil.GetOperation("test-1", "test-space", "test-mta-id", "deploy", "ERROR", true),
 					}, nil).Build()
 				output, status := oc.CaptureOutputAndStatus(func() int {
-					return command.Execute([]string{"--mta-id", "test-mta-id"}).ToInt()
+					return command.Execute([]string{"--mta", "test-mta-id"}).ToInt()
 				})
 				expectedOutput := getOutputLines([][]string{
 					[]string{"test-1", "deploy", "test-mta-id", "ERROR", "2016-03-04T14:23:24.521Z[Etc/UTC]", "admin"},

--- a/testutil/test_results.go
+++ b/testutil/test_results.go
@@ -56,7 +56,7 @@ var SimpleMtaLog = models.Log{
 // const Version = "1.2.0"
 // const ServiceID = "xs2-undeploy"
 const ProcessID = "1000"
-const LogID = "MAIN_LOG"
+const LogID = "OPERATION.log"
 const LogContent = "test-test-test"
 
 // const ActionID = "slp.action.ABORT"


### PR DESCRIPTION
Revert appending .log file extension to the logs files and expect that
this is done in the backend. Reword the --mta-id flag in dmol and
mta-ops to --mta.
