### PR TITLE
Retry calls to shared domains

### DIFF
--- a/clients/cfrestclient/resilient/resilient_rest_cloud_foundry_client_extended.go
+++ b/clients/cfrestclient/resilient/resilient_rest_cloud_foundry_client_extended.go
@@ -1,0 +1,31 @@
+package resilient
+
+import (
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/cfrestclient"
+	"github.com/cloudfoundry-incubator/multiapps-cli-plugin/clients/models"
+	"time"
+)
+
+type ResilientCloudFoundryRestClient struct {
+	CloudFoundryRestClient cfrestclient.CloudFoundryOperationsExtended
+	MaxRetriesCount        int
+	RetryInterval          time.Duration
+}
+
+func NewResilientCloudFoundryClient(cloudFoundryRestClient cfrestclient.CloudFoundryOperationsExtended, maxRetriesCount int, retryIntervalInSeconds int) cfrestclient.CloudFoundryOperationsExtended {
+	return &ResilientCloudFoundryRestClient{cloudFoundryRestClient, maxRetriesCount, time.Second * time.Duration(retryIntervalInSeconds)}
+}
+
+func (c ResilientCloudFoundryRestClient) GetSharedDomains() ([]models.SharedDomain, error) {
+	sharedDomains, err := c.CloudFoundryRestClient.GetSharedDomains()
+	for shouldRetry(c.MaxRetriesCount, err) {
+		sharedDomains, err = c.CloudFoundryRestClient.GetSharedDomains()
+		c.MaxRetriesCount--
+		time.Sleep(c.RetryInterval)
+	}
+	return sharedDomains, err
+}
+
+func shouldRetry(retries int, err error) bool {
+	return err != nil && retries > 0
+}


### PR DESCRIPTION
Sometimes some of our health checks fail because of the following error: "<landscape>/v2/shared_domains: net/http: TLS handshake timeout" which after a retry succeeds.
This PR implements such а resilient logic for getting the shared domains.

LMCROSSITXSADEPLOY-2131