### PR TITLE
Change checking for existing files

### DIFF
--- a/commands/file_uploader.go
+++ b/commands/file_uploader.go
@@ -184,19 +184,17 @@ func (f *FileUploader) uploadFilePart(filePart *os.File, baseFileName string) (*
 }
 
 func (f *FileUploader) isFileAlreadyUploaded(newFilePath string, fileInfo os.FileInfo, oldFiles []*models.FileMetadata, alreadyUploadedFiles *[]*models.FileMetadata) bool {
-	newFileDigests := make(map[string]string)
 	for _, oldFile := range oldFiles {
 		if oldFile.Name != fileInfo.Name() || oldFile.Namespace != f.namespace {
 			continue
 		}
-		if newFileDigests[oldFile.DigestAlgorithm] == "" {
-			digest, err := util.ComputeFileChecksum(newFilePath, oldFile.DigestAlgorithm)
-			if err != nil {
-				ui.Failed("Could not compute digest of file %s: %s", terminal.EntityNameColor(newFilePath), baseclient.NewClientError(err))
-			}
-			newFileDigests[oldFile.DigestAlgorithm] = strings.ToUpper(digest)
+		digest, err := util.ComputeFileChecksum(newFilePath, oldFile.DigestAlgorithm)
+		if err != nil {
+			ui.Failed("Could not compute digest of file %s: %s", terminal.EntityNameColor(newFilePath), baseclient.NewClientError(err))
+			return false
 		}
-		if newFileDigests[oldFile.DigestAlgorithm] == oldFile.Digest {
+
+		if strings.ToUpper(digest) == oldFile.Digest {
 			*alreadyUploadedFiles = append(*alreadyUploadedFiles, oldFile)
 			ui.Say("Previously uploaded file %s with same digest detected, new upload will be skipped.",
 				terminal.EntityNameColor(fileInfo.Name()))


### PR DESCRIPTION
The checking for existing files used the digest algorithm (which is always MD5) as the map key.
That way, the map will always contain a single entry which will be overridden with each consecutive file.
This changes the check for existing old files because a map is unneeded.