### PR TITLE
Retry failed client calls. Add unit tests for client_util

### DIFF
--- a/clients/baseclient/baseclient_suite_test.go
+++ b/clients/baseclient/baseclient_suite_test.go
@@ -1,0 +1,13 @@
+package baseclient_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBaseclient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Baseclient Suite")
+}

--- a/clients/baseclient/client_util.go
+++ b/clients/baseclient/client_util.go
@@ -2,6 +2,7 @@ package baseclient
 
 import (
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -22,6 +23,9 @@ func shouldRetry(err error) bool {
 	if err == nil {
 		return false
 	}
+	if isMatching(err) {
+		return true
+	}
 
 	ae, ok := err.(*ClientError)
 	if ok {
@@ -32,6 +36,16 @@ func shouldRetry(err error) bool {
 		}
 	}
 	return false
+}
+
+func isMatching(err error) bool {
+	return strings.Contains(err.Error(), "retry is needed") || isErrorEOF(err)
+}
+
+func isErrorEOF(err error) bool {
+	isMatching, _ := regexp.MatchString(" EOF$", err.Error())
+
+	return isMatching
 }
 
 func EncodeArg(arg string) string {

--- a/clients/baseclient/client_util.go
+++ b/clients/baseclient/client_util.go
@@ -2,7 +2,6 @@ package baseclient
 
 import (
 	"net/url"
-	"regexp"
 	"strings"
 	"time"
 )
@@ -23,28 +22,16 @@ func shouldRetry(err error) bool {
 	if err == nil {
 		return false
 	}
-	if isMatching(err) {
-		return true
-	}
+
 	ae, ok := err.(*ClientError)
 	if ok {
 		httpCode := ae.Code
 		httpCodeMajorDigit := httpCode / 100
-		if httpCodeMajorDigit == 5 || httpCodeMajorDigit == 4 {
+		if httpCodeMajorDigit != 2 {
 			return true
 		}
 	}
 	return false
-}
-
-func isMatching(err error) bool {
-	return strings.Contains(err.Error(), "retry is needed") || isErrorEOF(err)
-}
-
-func isErrorEOF(err error) bool {
-	isMatching, _ := regexp.MatchString(" EOF$", err.Error())
-
-	return isMatching
 }
 
 func EncodeArg(arg string) string {

--- a/clients/baseclient/client_util_test.go
+++ b/clients/baseclient/client_util_test.go
@@ -1,0 +1,108 @@
+package baseclient
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ClientUtil", func() {
+	Describe("ShouldRetry", func() {
+		Context("when zero value pointer error(uninitialized value - nil) is passed as argument", func() {
+			It("Retry operation call shouldn't be made", func() {
+				result := shouldRetry(nil)
+				Expect(result).To(Equal(false))
+			})
+		})
+
+		Context("when the backend returns status code with first digit 1 (1xx)", func() {
+			It("Retry operation call is expected to be made", func() {
+				err := ClientError{102, "Processing", "The request has been accepted but it's not yet complete"}
+				result := shouldRetry(&err)
+				Expect(result).To(Equal(true))
+			})
+		})
+
+		Context("when the backend returns status code with first digit 2 (2xx)", func() {
+			It("Retry operation call shouldn't be made", func() {
+				err := ClientError{200, "OK", "The request has succeeded"}
+				result := shouldRetry(&err)
+				Expect(result).To(Equal(false))
+			})
+		})
+
+		Context("when the backend returns status code with first digit 3 (3xx)", func() {
+			It("Retry operation call is expected to be made", func() {
+				err := ClientError{301, "Moved Permanently", "URI of requested resource has been changed"}
+				result := shouldRetry(&err)
+				Expect(result).To(Equal(true))
+			})
+		})
+
+		Context("when the backend returns status code with first digit 4 (4xx)", func() {
+			It("Retry operation call is expected to be made", func() {
+				err := ClientError{404, "Not Found", "The server cannot find requesred resource"}
+				result := shouldRetry(&err)
+				Expect(result).To(Equal(true))
+			})
+		})
+
+		Context("when the backend returns status code with first digit 5 (5xx)", func() {
+			It("Retry operation call is expected to be made", func() {
+				err := ClientError{500, "Internal Server Error", "The server got an invalid response"}
+				result := shouldRetry(&err)
+				Expect(result).To(Equal(true))
+			})
+		})
+
+		Context("when the passed error is not of type 'ClientError'", func() {
+			It("Retry operation call shouldn't be made", func() {
+				err := MockError{999, "Not ClientError"}
+				result := shouldRetry(&err)
+				Expect(result).To(Equal(false))
+			})
+		})
+	})
+})
+
+var _ = Describe("ClientUtil", func() {
+	Describe("CallWithRetry", func() {
+		Context("when retry operation call is Not needed", func() {
+			It("Just retrun required response", func() {
+				getInterface := func() (interface{}, error) {
+					toReturn := testStruct{}
+					return toReturn, nil
+				}
+				result, err := CallWithRetry(getInterface, 4, (time.Duration(0) * time.Second))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(result))
+			})
+		})
+		Context("when retry operation call IS needed", func() {
+			It("Callback with retry", func() {
+				mockCallback := func() (interface{}, error) {
+					toReturn := testStruct{}
+					err := ClientError{404, "Not Found", "The server cannot find requesred resource"}
+					return toReturn, &err
+				}
+				result, err := CallWithRetry(mockCallback, 4, (time.Duration(0) * time.Second))
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(Equal(result))
+			})
+		})
+	})
+})
+
+type MockError struct {
+	Code   int
+	Status string
+}
+
+func (ce *MockError) Error() string {
+	return fmt.Sprintf("%s (status %d)", ce.Status, ce.Code)
+}
+
+type testStruct struct {
+}


### PR DESCRIPTION
Problem fixed:
Not all failed calls to DS  are retried.

Description:
Currently this fix retires DS calls when their status code is different from [200-300). In some cases
this could prevent from deployment failures. 
The fix is tested with unit tests provided by the Ginkgo framework.

Issue: LMCROSSITXSADEPLOY-2270

