### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/multiapps-cli-plugin/security/code-scanning/3](https://github.com/cloudfoundry/multiapps-cli-plugin/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root in `.github/workflows/pull-request-build.yml` so all jobs inherit least-privilege token access unless overridden.  
For this workflow (checkout + Go build/test on PRs), the minimal required permission is:

- `contents: read`

Best single fix without changing behavior: insert

```yml
permissions:
  contents: read
```

directly after the `on:` trigger block (or near the top before `jobs:`). No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
