### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [synchronize, opened]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check_commit_message:
     name: Check Commit Message


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/multiapps-cli-plugin/security/code-scanning/2](https://github.com/cloudfoundry/multiapps-cli-plugin/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged and documented.  
Best fix without changing functionality: set workflow-level permissions to `contents: read` and `pull-requests: read`, since the script only lists PR commits and does not write anything.

Edit file **`.github/workflows/check-commit-message.yml`**, adding the permissions block after the `on` section (before `jobs`). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
